### PR TITLE
Permit build against system-wide libsamplerate

### DIFF
--- a/freeverb3/Makefile
+++ b/freeverb3/Makefile
@@ -1,12 +1,6 @@
 include Makefile.mk
 
 OBJS_FV3 = \
-	samplerate.c.o \
-	samplerate_common.c.o \
-	src_common.c.o \
-	src_linear.c.o \
-	src_sinc.c.o \
-	src_zoh.c.o \
 	allpass.cpp.o \
 	biquad.cpp.o \
 	comb.cpp.o \
@@ -21,13 +15,29 @@ OBJS_FV3 = \
 	zrev.cpp.o \
 	zrev2.cpp.o
 
+ifneq ($(SYSTEM_LIBSAMPLERATE),true)
+OBJS_FV3 += \
+	samplerate.c.o \
+	samplerate_common.c.o \
+	src_common.c.o \
+	src_linear.c.o \
+	src_sinc.c.o \
+	src_zoh.c.o
+endif
+
 all: $(OBJS_FV3)
 
+ifneq ($(SYSTEM_LIBSAMPLERATE),true)
 %.c.o: libsamplerate2/%.c
 	$(CC) $< $(BUILD_C_FLAGS) -I. -DLIBSRATE2_FLOAT -c -o $@
+endif
 
 %.cpp.o: freeverb/%.cpp
+ifneq ($(SYSTEM_LIBSAMPLERATE),true)
 	$(CXX) $< $(BUILD_CXX_FLAGS) -I. -DLIBSRATE2_FLOAT -DLIBFV3_FLOAT -Wno-unused-parameter -c -o $@
+else
+	$(CXX) $< $(BUILD_CXX_FLAGS) -I. -DLIBSRATE1 -DLIBFV3_FLOAT -Wno-unused-parameter -c -o $@
+endif
 
 clean:
 	rm -f *.d *.o

--- a/freeverb3/freeverb/earlyref.hpp
+++ b/freeverb3/freeverb/earlyref.hpp
@@ -38,6 +38,8 @@ namespace fv3
 #undef _FV3_
 #undef _fv3_float_t
 
+#ifndef LIBSRATE1
+
 #define _fv3_float_t double
 #define _FV3_(name) name ## _
 #include "freeverb/earlyref_t.hpp"
@@ -49,6 +51,8 @@ namespace fv3
 #include "freeverb/earlyref_t.hpp"
 #undef _FV3_
 #undef _fv3_float_t
+
+#endif // LIBSRATE1
 
 };
 

--- a/freeverb3/freeverb/fv3_type_float.h
+++ b/freeverb3/freeverb/fv3_type_float.h
@@ -27,7 +27,11 @@
 typedef float fv3_float_t;
 #define FV3_(name) name ## _f
 #define FFTW_(name) fftwf_ ## name
+#ifdef LIBSRATE1
+#define SRC_(name) name
+#else // LIBSRATE1
 #define SRC_(name) name ## _f
+#endif // LIBSRATE1
 #else
 #ifdef LIBFV3_DOUBLE
 typedef double fv3_float_t;

--- a/freeverb3/freeverb/revbase.hpp
+++ b/freeverb3/freeverb/revbase.hpp
@@ -39,6 +39,8 @@ namespace fv3
 #undef _FV3_
 #undef _fv3_float_t
 
+#ifndef LIBSRATE1
+
 #define _fv3_float_t double
 #define _FV3_(name) name ## _
 #include "freeverb/revbase_t.hpp"
@@ -50,6 +52,8 @@ namespace fv3
 #include "freeverb/revbase_t.hpp"
 #undef _FV3_
 #undef _fv3_float_t
+
+#endif // LIBSRATE1
 
 };
 

--- a/freeverb3/freeverb/src.hpp
+++ b/freeverb3/freeverb/src.hpp
@@ -22,7 +22,11 @@
 #define _FV3_SRC_HPP
 
 #include <cstdio>
+#ifdef LIBSRATE1
+#include <samplerate.h>
+#else
 #include <libsamplerate2/samplerate2.h>
+#endif
 #include "freeverb/utils.hpp"
 #include "freeverb/efilter.hpp"
 #include "freeverb/biquad.hpp"
@@ -30,6 +34,18 @@
 
 namespace fv3
 {
+
+#ifdef LIBSRATE1
+
+#define _fv3_float_t float
+#define _FV3_(name) name ## _f
+#define _SRC_(name) name
+#include "freeverb/src_t.hpp"
+#undef _FV3_
+#undef _SRC_
+#undef _fv3_float_t
+
+#else // LIBSRATE1
 
 #define _fv3_float_t float
 #define _FV3_(name) name ## _f
@@ -54,6 +70,8 @@ namespace fv3
 #undef _FV3_
 #undef _SRC_
 #undef _fv3_float_t
+
+#endif // LIBSRATE1
 
 };
 

--- a/freeverb3/freeverb/src_t.hpp
+++ b/freeverb3/freeverb/src_t.hpp
@@ -47,7 +47,11 @@ class _FV3_(src)
   long overSamplingFactor, src_converter, latency;
   _SRC_(SRC_STATE) *src_stateL, *src_stateR, *src_stateLV, *src_stateRV;
   _SRC_(SRC_DATA) src_dataL, src_dataR, src_dataLV, src_dataRV;
+#ifdef LIBSRATE1
+  int src_errorL, src_errorR;
+#else
   long src_errorL, src_errorR;
+#endif
   _FV3_(iir_1st) up1L, up1R, down1L, down1R;
   _FV3_(biquad) up2L, up2R, down2L, down2R;
   _fv3_float_t lpf_iir2_bw;

--- a/freeverb3/freeverb/zrev.hpp
+++ b/freeverb3/freeverb/zrev.hpp
@@ -39,6 +39,8 @@ namespace fv3
 #undef _FV3_
 #undef _fv3_float_t
 
+#ifndef LIBSRATE1
+
 #define _fv3_float_t double
 #define _FV3_(name) name ## _
 #include "freeverb/zrev_t.hpp"
@@ -50,6 +52,8 @@ namespace fv3
 #include "freeverb/zrev_t.hpp"
 #undef _FV3_
 #undef _fv3_float_t
+
+#endif // LIBSRATE1
 
 };
 

--- a/freeverb3/freeverb/zrev2.hpp
+++ b/freeverb3/freeverb/zrev2.hpp
@@ -37,6 +37,8 @@ namespace fv3
 #undef _FV3_
 #undef _fv3_float_t
 
+#ifndef LIBSRATE1
+
 #define _fv3_float_t double
 #define _FV3_(name) name ## _
 #include "freeverb/zrev2_t.hpp"
@@ -48,6 +50,8 @@ namespace fv3
 #include "freeverb/zrev2_t.hpp"
 #undef _FV3_
 #undef _fv3_float_t
+
+#endif // LIBSRATE1
 
 };
 

--- a/plugins/dragonfly-reverb/Makefile
+++ b/plugins/dragonfly-reverb/Makefile
@@ -30,10 +30,19 @@ FILES_UI  = \
 
 include ../../dpf/Makefile.plugins.mk
 
-BUILD_CXX_FLAGS := ../../freeverb3/*.cpp.o ../../freeverb3/*.c.o -I../../freeverb3 $(BUILD_CXX_FLAGS)
+BUILD_CXX_FLAGS := ../../freeverb3/*.cpp.o -I../../freeverb3 $(BUILD_CXX_FLAGS)
+ifneq ($(SYSTEM_LIBSAMPLERATE),true)
+BUILD_CXX_FLAGS := ../../freeverb3/*.c.o $(BUILD_CXX_FLAGS)
+endif
 
 # --------------------------------------------------------------
 # Link dependencies
+
+ifeq ($(SYSTEM_LIBSAMPLERATE),true)
+BUILD_C_FLAGS := -DLIBSRATE1 $(BUILD_C_FLAGS)
+BUILD_CXX_FLAGS := -DLIBSRATE1 $(BUILD_CXX_FLAGS)
+LINK_OPTS += -lsamplerate
+endif
 
 LINK_OPTS += -lm
 


### PR DESCRIPTION
#28 

This is work to permit a build a Dragonfly Reverb based on the installed version of libsamplerate, instead of the code shippped with Freeverb3.
This is enabled by passing `SYSTEM_LIBSAMPLERATE=true` to `make`.

I add a conditional compilation on Freeverb3 side, with flag `-DLIBSRATE1`.
When this is on, the code supporting `double` and `long double` is excluded, because libsamplerate1 only supports the single-precision float type. Also, the API is identified without the `_f` suffix.

notify @trebmuh 