### PR TITLE
Fix invalid access on array by 1 element

### DIFF
--- a/common/Spectrogram.cpp
+++ b/common/Spectrogram.cpp
@@ -172,7 +172,7 @@ void Spectrogram::onDisplay() {
   fNanoText->fontSize ( 16 );
   fNanoText->textAlign ( NanoVG::ALIGN_RIGHT | NanoVG::ALIGN_MIDDLE );
 
-  for ( int i = 0 ; i < 6 ; i++ ) {
+  for ( int i = 0 ; i < 5 ; i++ ) {
     int x = ( int ) ( image->getWidth() * logf ( decayTime[i] / SPECTROGRAM_MIN_SECONDS ) / logf ( SPECTROGRAM_MAX_SECONDS / SPECTROGRAM_MIN_SECONDS ) );
     fNanoText->textBox ( x , getHeight() - 5 , 40.0f , decayTimeString[i].c_str(), nullptr );
   }


### PR DESCRIPTION
#46

Fixes the invalid access making the beta unusable on some platforms, crashing soon after startup.

I think this is fine, the arrays `decayTime` and `decayTimeString` are both 5 long.