### PR TITLE
devendor freeverb3 with environment variable

### DIFF
--- a/common/Makefile
+++ b/common/Makefile
@@ -1,6 +1,11 @@
 include Makefile.mk
 
 OBJS = \
+	kiss_fft/kiss_fft.c.o \
+	kiss_fft/kiss_fftr.c.o
+
+ifneq ($(SYSTEM_FREEVERB3),true)
+OBJS += \
 	freeverb/allpass.cpp.o \
 	freeverb/biquad.cpp.o \
 	freeverb/comb.cpp.o \
@@ -18,6 +23,7 @@ OBJS = \
 	freeverb/zrev2.cpp.o \
 	kiss_fft/kiss_fft.c.o \
 	kiss_fft/kiss_fftr.c.o
+endif
 
 ifneq ($(SYSTEM_LIBSAMPLERATE),true)
 OBJS += \
@@ -36,11 +42,14 @@ libsamplerate2/%.c.o: libsamplerate2/%.c
 	$(CC) $< $(BUILD_C_FLAGS) -I. -DLIBSRATE2_FLOAT -c -o $@
 endif
 
+
+ifneq ($(SYSTEM_FREEVERB3),true)
 freeverb/%.cpp.o: freeverb/%.cpp
 ifneq ($(SYSTEM_LIBSAMPLERATE),true)
 	$(CXX) $< $(BUILD_CXX_FLAGS) -I. -DLIBSRATE2_FLOAT -DLIBFV3_FLOAT -Wno-unused-parameter -c -o $@
 else
 	$(CXX) $< $(BUILD_CXX_FLAGS) -I. -DLIBSRATE1 -DLIBFV3_FLOAT -Wno-unused-parameter -c -o $@
+endif
 endif
 
 kiss_fft/%.c.o: kiss_fft/%.c

--- a/plugins/dragonfly-hall-reverb/Makefile
+++ b/plugins/dragonfly-hall-reverb/Makefile
@@ -31,7 +31,11 @@ include ../../dpf/Makefile.plugins.mk
 
 BUILD_CXX_FLAGS := -I../../common $(BUILD_CXX_FLAGS)
 BUILD_CXX_FLAGS := ../../common/kiss_fft/*.c.o $(BUILD_CXX_FLAGS)
+ifneq ($(SYSTEM_FREEVERB3),true)
 BUILD_CXX_FLAGS := ../../common/freeverb/*.cpp.o $(BUILD_CXX_FLAGS)
+else
+BUILD_CXX_FLAGS := $(shell pkg-config --cflags freeverb3-3) $(BUILD_CXX_FLAGS)
+endif
 
 ifneq ($(SYSTEM_LIBSAMPLERATE),true)
 BUILD_CXX_FLAGS := ../../common/libsamplerate2/*.c.o $(BUILD_CXX_FLAGS)
@@ -46,7 +50,12 @@ BUILD_CXX_FLAGS := -DLIBSRATE1 $(BUILD_CXX_FLAGS)
 LINK_OPTS += -lsamplerate
 endif
 
+ifneq ($(SYSTEM_FREEVERB3),true)
 LINK_OPTS += -lm
+else
+LINK_OPTS += -lm $(shell pkg-config --libs freeverb3-3)
+endif
+
 
 ifeq ($(WIN32),true)
 LINK_OPTS += -static -static-libgcc -static-libstdc++

--- a/plugins/dragonfly-room-reverb/Makefile
+++ b/plugins/dragonfly-room-reverb/Makefile
@@ -31,7 +31,11 @@ include ../../dpf/Makefile.plugins.mk
 
 BUILD_CXX_FLAGS := -I../../common $(BUILD_CXX_FLAGS)
 BUILD_CXX_FLAGS := ../../common/kiss_fft/*.c.o $(BUILD_CXX_FLAGS)
+ifneq ($(SYSTEM_FREEVERB3),true)
 BUILD_CXX_FLAGS := ../../common/freeverb/*.cpp.o $(BUILD_CXX_FLAGS)
+else
+BUILD_CXX_FLAGS := $(shell pkg-config --cflags freeverb3-3) $(BUILD_CXX_FLAGS)
+endif
 
 ifneq ($(SYSTEM_LIBSAMPLERATE),true)
 BUILD_CXX_FLAGS := ../../common/libsamplerate2/*.c.o $(BUILD_CXX_FLAGS)
@@ -46,7 +50,11 @@ BUILD_CXX_FLAGS := -DLIBSRATE1 $(BUILD_CXX_FLAGS)
 LINK_OPTS += -lsamplerate
 endif
 
+ifneq ($(SYSTEM_FREEVERB3),true)
 LINK_OPTS += -lm
+else
+LINK_OPTS += -lm $(shell pkg-config --libs freeverb3-3)
+endif
 
 ifeq ($(WIN32),true)
 LINK_OPTS += -static -static-libgcc -static-libstdc++


### PR DESCRIPTION
{common/Makefile,plugins/*/Makefile}: Devendor freeverb3, when using `SYSTEM_FREEVERB3=true` during `make`.