### PR TITLE
Bugfix Hall reverb DSP.hpp

### DIFF
--- a/plugins/dragonfly-hall-reverb/DSP.hpp
+++ b/plugins/dragonfly-hall-reverb/DSP.hpp
@@ -35,10 +35,10 @@ private:
   float oldParams[paramCount];
   float newParams[paramCount];
 
-  float dry_level;
-  float early_level;
-  float early_send;
-  float late_level;
+  float dry_level = 0.0;
+  float early_level = 0.0;
+  float early_send = 0.0;
+  float late_level = 0.0;
 
   fv3::earlyref_f early;
   fv3::zrev2_f late;


### PR DESCRIPTION
Fixes bug of uninitialized floats, which can result in clipping.

Why is this needed?
It might happen, that the oldParams are equal to 0.0. The host might set one of this parameters to 0.0. Which means, that the value isn't propagetd in DragonflyReverbDSP::run to the members. Since they are uninitialized this can result in an huge overdrive.