### PR TITLE
Use SSE only for supported architectures

### DIFF
--- a/common/Makefile.mk
+++ b/common/Makefile.mk
@@ -23,7 +23,11 @@ endif
 # Set build and link flags
 
 BASE_FLAGS = -Wall -Wextra -pipe -MD -MP
-BASE_OPTS  = -O2 -mtune=generic -msse -msse2 -fdata-sections -ffunction-sections
+BASE_OPTS  = -O2 -fdata-sections -ffunction-sections
+
+ifeq ($(CPU_I386_OR_X86_64),true)
+BASE_OPTS += -mtune=generic -msse -msse2
+endif
 
 ifeq ($(MACOS),true)
 # MacOS linker flags


### PR DESCRIPTION
... otherwise the build will fail.