### PR TITLE
Update DPF-based CI file, add plugin validation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,181 +9,315 @@ on:
       - '*'
 env:
   DEBIAN_FRONTEND: noninteractive
+  HOMEBREW_NO_AUTO_UPDATE: 1
 
 jobs:
   linux-arm64:
     runs-on: ubuntu-18.04
     steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: recursive
-    - name: Set up dependencies
-      run: |
-        sudo dpkg --add-architecture arm64 && \
-        sudo sed -i "s/deb http/deb [arch=amd64] http/" /etc/apt/sources.list && \
-        echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports bionic main restricted universe multiverse" | sudo tee /etc/apt/sources.list.d/ports-arm64.list && \
-        echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports bionic-updates main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list.d/ports-arm64.list && \
-        echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports bionic-backports main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list.d/ports-arm64.list && \
-        sudo apt-get update -qq && \
-        sudo apt-get install -yq g++-aarch64-linux-gnu libasound2-dev:arm64 libcairo2-dev:arm64 libgl1-mesa-dev:arm64 liblo-dev:arm64 libpulse-dev:arm64 qemu-user-static
-    - name: Build linux arm64 cross-compiled
-      env:
-        CC: aarch64-linux-gnu-gcc
-        CXX: aarch64-linux-gnu-g++
-        LDFLAGS: -static-libgcc -static-libstdc++
-      run: |
-        make -j $(nproc)
-    - name: Set sha8
-      id: slug
-      run: echo "::set-output name=sha8::$(echo ${{ github.sha }} | cut -c1-8)"
-    - uses: actions/upload-artifact@v2
-      with:
-        name: ${{ github.event.repository.name }}-linux-arm64-${{ github.event.pull_request.number || steps.slug.outputs.sha8 }}
-        path: |
-          bin/*
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Set up dependencies
+        run: |
+          sudo dpkg --add-architecture arm64
+          sudo sed -i "s/deb http/deb [arch=amd64] http/" /etc/apt/sources.list
+          echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports bionic main restricted universe multiverse" | sudo tee /etc/apt/sources.list.d/ports-arm64.list
+          echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports bionic-updates main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list.d/ports-arm64.list
+          echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports bionic-backports main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list.d/ports-arm64.list
+          sudo apt-get update -qq
+          sudo apt-get install -yq g++-aarch64-linux-gnu libasound2-dev:arm64 libcairo2-dev:arm64 libgl1-mesa-dev:arm64 liblo-dev:arm64 libpulse-dev:arm64 libx11-dev:arm64 libxcursor-dev:arm64 libxext-dev:arm64 libxrandr-dev:arm64 qemu-user-static
+          # fix broken Ubuntu packages missing pkg-config file in multi-arch package
+          sudo apt-get install -yq libasound2-dev libgl1-mesa-dev liblo-dev libpulse-dev libxcursor-dev libxrandr-dev
+          sudo ln -s /usr/lib/aarch64-linux-gnu/liblo.so.7 /usr/lib/aarch64-linux-gnu/liblo.so
+          sudo cp /usr/lib/x86_64-linux-gnu/pkgconfig/liblo.pc /usr/lib/aarch64-linux-gnu/pkgconfig/liblo.pc
+          sudo sed -i "s/x86_64-linux-gnu/aarch64-linux-gnu/" /usr/lib/aarch64-linux-gnu/pkgconfig/liblo.pc
+      - name: Build linux arm64 cross-compiled
+        env:
+          CC: aarch64-linux-gnu-gcc
+          CXX: aarch64-linux-gnu-g++
+          LDFLAGS: -static-libgcc -static-libstdc++
+        run: |
+          make features
+          make -j $(nproc)
+      - name: Set sha8
+        id: slug
+        run: echo "::set-output name=sha8::$(echo ${{ github.sha }} | cut -c1-8)"
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ github.event.repository.name }}-linux-arm64-${{ github.event.pull_request.number || steps.slug.outputs.sha8 }}
+          path: |
+            bin/*
 
   linux-armhf:
     runs-on: ubuntu-18.04
     steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: recursive
-    - name: Set up dependencies
-      run: |
-        sudo dpkg --add-architecture armhf && \
-        sudo sed -i "s/deb http/deb [arch=amd64] http/" /etc/apt/sources.list && \
-        echo "deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports bionic main restricted universe multiverse" | sudo tee /etc/apt/sources.list.d/ports-armhf.list && \
-        echo "deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports bionic-updates main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list.d/ports-armhf.list && \
-        echo "deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports bionic-backports main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list.d/ports-armhf.list && \
-        sudo apt-get update -qq && \
-        sudo apt-get install -yq g++-arm-linux-gnueabihf libasound2-dev:armhf libcairo2-dev:armhf libgl1-mesa-dev:armhf liblo-dev:armhf libpulse-dev:armhf qemu-user-static
-    - name: Build linux armhf cross-compiled
-      env:
-        CC: arm-linux-gnueabihf-gcc
-        CXX: arm-linux-gnueabihf-g++
-        LDFLAGS: -static-libgcc -static-libstdc++
-      run: |
-        make -j $(nproc)
-    - name: Set sha8
-      id: slug
-      run: echo "::set-output name=sha8::$(echo ${{ github.sha }} | cut -c1-8)"
-    - uses: actions/upload-artifact@v2
-      with:
-        name: ${{ github.event.repository.name }}-linux-armhf-${{ github.event.pull_request.number || steps.slug.outputs.sha8 }}
-        path: |
-          bin/*
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Set up dependencies
+        run: |
+          sudo dpkg --add-architecture armhf
+          sudo sed -i "s/deb http/deb [arch=amd64] http/" /etc/apt/sources.list
+          echo "deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports bionic main restricted universe multiverse" | sudo tee /etc/apt/sources.list.d/ports-armhf.list
+          echo "deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports bionic-updates main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list.d/ports-armhf.list
+          echo "deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports bionic-backports main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list.d/ports-armhf.list
+          sudo apt-get update -qq
+          sudo apt-get install -yq g++-arm-linux-gnueabihf libasound2-dev:armhf libcairo2-dev:armhf libgl1-mesa-dev:armhf liblo-dev:armhf libpulse-dev:armhf libx11-dev:armhf libxcursor-dev:armhf libxext-dev:armhf libxrandr-dev:armhf qemu-user-static
+          # fix broken Ubuntu packages missing pkg-config file in multi-arch package
+          sudo apt-get install -yq libasound2-dev libgl1-mesa-dev liblo-dev libpulse-dev libxcursor-dev libxrandr-dev
+          sudo ln -s /usr/lib/arm-linux-gnueabihf/liblo.so.7 /usr/lib/arm-linux-gnueabihf/liblo.so
+          sudo cp /usr/lib/x86_64-linux-gnu/pkgconfig/liblo.pc /usr/lib/arm-linux-gnueabihf/pkgconfig/liblo.pc
+          sudo sed -i "s/x86_64-linux-gnu/arm-linux-gnueabihf/" /usr/lib/arm-linux-gnueabihf/pkgconfig/liblo.pc
+      - name: Build linux armhf cross-compiled
+        env:
+          CC: arm-linux-gnueabihf-gcc
+          CXX: arm-linux-gnueabihf-g++
+          LDFLAGS: -static-libgcc -static-libstdc++
+        run: |
+          make features
+          make -j $(nproc)
+      - name: Set sha8
+        id: slug
+        run: echo "::set-output name=sha8::$(echo ${{ github.sha }} | cut -c1-8)"
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ github.event.repository.name }}-linux-armhf-${{ github.event.pull_request.number || steps.slug.outputs.sha8 }}
+          path: |
+            bin/*
 
-  linux-x64:
+  linux-x86:
     runs-on: ubuntu-18.04
     steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: recursive
-    - name: Set up dependencies
-      run: |
-        sudo apt-get install -yq libasound2-dev libgl1-mesa-dev liblo-dev libpulse-dev
-    - name: Build linux x64
-      env:
-        LDFLAGS: -static-libgcc -static-libstdc++
-      run: |
-        make -j $(nproc)
-    - name: Set sha8
-      id: slug
-      run: echo "::set-output name=sha8::$(echo ${{ github.sha }} | cut -c1-8)"
-    - uses: actions/upload-artifact@v2
-      with:
-        name: ${{ github.event.repository.name }}-linux-x64-${{ github.event.pull_request.number || steps.slug.outputs.sha8 }}
-        path: |
-          bin/*
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Set up dependencies
+        run: |
+          sudo dpkg --add-architecture i386
+          sudo apt-get update -qq
+          sudo apt-get install -yq g++-multilib libasound2-dev:i386 libcairo2-dev:i386 libgl1-mesa-dev:i386 liblo-dev:i386 libpulse-dev:i386 libx11-dev:i386 libxcursor-dev:i386 libxext-dev:i386 libxrandr-dev:i386
+      - name: Build linux x86
+        env:
+          CFLAGS: -m32
+          CXXFLAGS: -m32
+          LDFLAGS: -m32 -static-libgcc -static-libstdc++
+          PKG_CONFIG_PATH: /usr/lib/i386-linux-gnu/pkgconfig
+        run: |
+          make features
+          make -j $(nproc)
+      - name: Set sha8
+        id: slug
+        run: echo "::set-output name=sha8::$(echo ${{ github.sha }} | cut -c1-8)"
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ github.event.repository.name }}-linux-x86-${{ github.event.pull_request.number || steps.slug.outputs.sha8 }}
+          path: |
+            bin/*
+
+  linux-x86_64:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Set up dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -yq libasound2-dev libcairo2-dev libgl1-mesa-dev liblo-dev libpulse-dev libx11-dev libxcursor-dev libxext-dev libxrandr-dev
+      - name: Build linux x86_64
+        env:
+          LDFLAGS: -static-libgcc -static-libstdc++
+        run: |
+          make features
+          make -j $(nproc)
+      - name: Set sha8
+        id: slug
+        run: echo "::set-output name=sha8::$(echo ${{ github.sha }} | cut -c1-8)"
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ github.event.repository.name }}-linux-x86_64-${{ github.event.pull_request.number || steps.slug.outputs.sha8 }}
+          path: |
+            bin/*
 
   macos-universal:
     runs-on: macos-10.15
     steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: recursive
-    - name: Fix up Xcode
-      run: |
-        sudo rm -Rf /Library/Developer/CommandLineTools/SDKs/*
-        sudo xcode-select -s "/Applications/Xcode_12.3.app"
-    - name: Build macOS universal
-      env:
-        CFLAGS: -arch x86_64 -arch arm64 -DMAC_OS_X_VERSION_MAX_ALLOWED=MAC_OS_X_VERSION_10_12 -mmacosx-version-min=10.12 -mtune=generic -msse -msse2
-        CXXFLAGS: -arch x86_64 -arch arm64 -DMAC_OS_X_VERSION_MAX_ALLOWED=MAC_OS_X_VERSION_10_12 -mmacosx-version-min=10.12 -mtune=generic -msse -msse2
-        LDFLAGS: -arch x86_64 -arch arm64 -mmacosx-version-min=10.12
-      run: |
-        make NOOPT=true -j $(sysctl -n hw.logicalcpu) && \
-        ./dpf/utils/package-osx-bundles.sh
-    - name: Set sha8
-      id: slug
-      run: echo "::set-output name=sha8::$(echo ${{ github.sha }} | cut -c1-8)"
-    - uses: actions/upload-artifact@v2
-      with:
-        name: ${{ github.event.repository.name }}-macOS-universal-${{ github.event.pull_request.number || steps.slug.outputs.sha8 }}
-        path: |
-          *-macOS.pkg
-          bin/*
-          !bin/*-ladspa.dylib
-          !bin/*-dssi.dylib
-          !bin/lv2
-          !bin/vst2
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Fix up Xcode
+        run: |
+          sudo rm -Rf /Library/Developer/CommandLineTools/SDKs/*
+          sudo xcode-select -s "/Applications/Xcode_12.3.app"
+      - name: Build macOS universal
+        env:
+          CFLAGS: -arch x86_64 -arch arm64 -DMAC_OS_X_VERSION_MAX_ALLOWED=MAC_OS_X_VERSION_10_12 -mmacosx-version-min=10.12 -mtune=generic -msse -msse2
+          CXXFLAGS: -arch x86_64 -arch arm64 -DMAC_OS_X_VERSION_MAX_ALLOWED=MAC_OS_X_VERSION_10_12 -mmacosx-version-min=10.12 -mtune=generic -msse -msse2
+          LDFLAGS: -arch x86_64 -arch arm64 -mmacosx-version-min=10.12
+        run: |
+          make features
+          make NOOPT=true -j $(sysctl -n hw.logicalcpu)
+          ./dpf/utils/package-osx-bundles.sh
+      - name: Set sha8
+        id: slug
+        run: echo "::set-output name=sha8::$(echo ${{ github.sha }} | cut -c1-8)"
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ github.event.repository.name }}-macOS-universal-${{ github.event.pull_request.number || steps.slug.outputs.sha8 }}
+          path: |
+            *-macOS.pkg
+            bin/*
+            !bin/*-ladspa.dylib
+            !bin/*-dssi.dylib
+            !bin/lv2
+            !bin/vst2
 
   win32:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: recursive
-    - name: Set up dependencies
-      run: |
-        sudo dpkg --add-architecture i386 && \
-        sudo apt-get update -qq && \
-        sudo apt-get install -yq binutils-mingw-w64-i686 g++-mingw-w64-i686 mingw-w64 wine-stable:i386
-    - name: Build win32 cross-compiled
-      env:
-        CC: i686-w64-mingw32-gcc
-        CXX: i686-w64-mingw32-g++
-        EXE_WRAPPER: wine
-        PKG_CONFIG: "false"
-        WINEDEBUG: "-all"
-      run: |
-        make -j $(nproc)
-    - name: Set sha8
-      id: slug
-      run: echo "::set-output name=sha8::$(echo ${{ github.sha }} | cut -c1-8)"
-    - uses: actions/upload-artifact@v2
-      with:
-        name: ${{ github.event.repository.name }}-win32-${{ github.event.pull_request.number || steps.slug.outputs.sha8 }}
-        path: |
-          bin/*
-          !bin/*-ladspa.dll
-          !bin/*-dssi.dll
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Set up dependencies
+        run: |
+          sudo dpkg --add-architecture i386
+          sudo apt-get update -qq
+          sudo apt-get install -yq binutils-mingw-w64-i686 g++-mingw-w64-i686 mingw-w64 wine-stable:i386
+      - name: Build win32 cross-compiled
+        env:
+          CC: i686-w64-mingw32-gcc
+          CXX: i686-w64-mingw32-g++
+          EXE_WRAPPER: wine
+          PKG_CONFIG: "false"
+          WINEDEBUG: "-all"
+        run: |
+          make features
+          make -j $(nproc)
+      - name: Set sha8
+        id: slug
+        run: echo "::set-output name=sha8::$(echo ${{ github.sha }} | cut -c1-8)"
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ github.event.repository.name }}-win32-${{ github.event.pull_request.number || steps.slug.outputs.sha8 }}
+          path: |
+            bin/*
+            !bin/*-ladspa.dll
+            !bin/*-dssi.dll
 
   win64:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: recursive
-    - name: Set up dependencies
-      run: |
-        sudo apt-get install -yq binutils-mingw-w64-x86-64 g++-mingw-w64-x86-64 mingw-w64 wine-stable
-    - name: Build win64 cross-compiled
-      env:
-        CC: x86_64-w64-mingw32-gcc
-        CXX: x86_64-w64-mingw32-g++
-        EXE_WRAPPER: wine
-        PKG_CONFIG: "false"
-        WINEDEBUG: "-all"
-      run: |
-        make -j $(nproc)
-    - name: Set sha8
-      id: slug
-      run: echo "::set-output name=sha8::$(echo ${{ github.sha }} | cut -c1-8)"
-    - uses: actions/upload-artifact@v2
-      with:
-        name: ${{ github.event.repository.name }}-win64-${{ github.event.pull_request.number || steps.slug.outputs.sha8 }}
-        path: |
-          bin/*
-          !bin/*-ladspa.dll
-          !bin/*-dssi.dll
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Set up dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -yq binutils-mingw-w64-x86-64 g++-mingw-w64-x86-64 mingw-w64 wine-stable
+      - name: Build win64 cross-compiled
+        env:
+          CC: x86_64-w64-mingw32-gcc
+          CXX: x86_64-w64-mingw32-g++
+          EXE_WRAPPER: wine
+          PKG_CONFIG: "false"
+          WINEDEBUG: "-all"
+        run: |
+          make features
+          make -j $(nproc)
+      - name: Set sha8
+        id: slug
+        run: echo "::set-output name=sha8::$(echo ${{ github.sha }} | cut -c1-8)"
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ github.event.repository.name }}-win64-${{ github.event.pull_request.number || steps.slug.outputs.sha8 }}
+          path: |
+            bin/*
+            !bin/*-ladspa.dll
+            !bin/*-dssi.dll
+
+  plugin-validation:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Set up dependencies
+        run: |
+          # custom repos
+          wget https://launchpad.net/~kxstudio-debian/+archive/kxstudio/+files/kxstudio-repos_10.0.3_all.deb
+          sudo dpkg -i kxstudio-repos_10.0.3_all.deb
+          sudo apt-get update -qq
+          # build-deps
+          sudo apt-get install -yq libasound2-dev libcairo2-dev libgl1-mesa-dev liblo-dev libpulse-dev libx11-dev libxcursor-dev libxext-dev libxrandr-dev
+          # runtime testing
+          sudo apt-get install -yq carla-git lilv-utils lv2-dev lv2lint valgrind
+      - name: Build plugins
+        env:
+          CFLAGS: -g
+          CXXFLAGS: -g
+          LDFLAGS: -static-libgcc -static-libstdc++
+        run: |
+          make features
+          make NOOPT=true SKIP_STRIPPING=true -j $(nproc)
+      - name: Validate LV2 ttl syntax
+        run: |
+          lv2_validate \
+              /usr/lib/lv2/mod.lv2/*.ttl \
+              /usr/lib/lv2/kx-meta/*.ttl \
+              /usr/lib/lv2/kx-control-input-port-change-request.lv2/*.ttl \
+              /usr/lib/lv2/kx-programs.lv2/*.ttl \
+              ./bin/*.lv2/*.ttl
+      - name: Validate LV2 metadata and binaries
+        run: |
+          export LV2_PATH=/tmp/lv2-path
+          mkdir ${LV2_PATH}
+          cp -r bin/*.lv2 \
+              /usr/lib/lv2/{atom,buf-size,core,data-access,kx-control-input-port-change-request,kx-programs,instance-access,midi,parameters,port-groups,port-props,options,patch,presets,resize-port,state,time,ui,units,urid,worker}.lv2 \
+              ${LV2_PATH}
+          lv2lint -s lv2_generate_ttl -l ld-linux-x86-64.so.2 -M nopack $(lv2ls)
+      - name: Test LADSPA plugins
+        run: |
+            for p in $(ls bin/ | grep ladspa.so); do \
+                env CARLA_BRIDGE_DUMMY=1 CARLA_BRIDGE_TESTING=native \
+                    valgrind \
+                    --error-exitcode=255 \
+                    --leak-check=full \
+                    --track-origins=yes \
+                    --suppressions=./dpf/utils/valgrind-dpf.supp \
+                    /usr/lib/carla/carla-bridge-native ladspa ./bin/${p} "" 1>/dev/null; \
+            done
+      - name: Test DSSI plugins
+        run: |
+            for p in $(ls bin/ | grep dssi.so); do \
+                env CARLA_BRIDGE_DUMMY=1 CARLA_BRIDGE_TESTING=native \
+                    valgrind \
+                    --error-exitcode=255 \
+                    --leak-check=full \
+                    --track-origins=yes \
+                    --suppressions=./dpf/utils/valgrind-dpf.supp \
+                    /usr/lib/carla/carla-bridge-native dssi ./bin/${p} "" 1>/dev/null; \
+            done
+      - name: Test LV2 plugins
+        run: |
+            export LV2_PATH=/tmp/lv2-path
+            for p in $(lv2ls); do \
+                env CARLA_BRIDGE_DUMMY=1 CARLA_BRIDGE_TESTING=native \
+                    valgrind \
+                    --error-exitcode=255 \
+                    --leak-check=full \
+                    --track-origins=yes \
+                    --suppressions=./dpf/utils/valgrind-dpf.supp \
+                    /usr/lib/carla/carla-bridge-native lv2 "" ${p} 1>/dev/null; \
+            done
+      - name: Test VST2 plugins
+        run: |
+            for p in $(ls bin/ | grep vst.so); do \
+                env CARLA_BRIDGE_DUMMY=1 CARLA_BRIDGE_TESTING=native \
+                    valgrind \
+                    --error-exitcode=255 \
+                    --leak-check=full \
+                    --track-origins=yes \
+                    --suppressions=./dpf/utils/valgrind-dpf.supp \
+                    /usr/lib/carla/carla-bridge-native vst2 ./bin/${p} "" 1>/dev/null; \
+            done


### PR DESCRIPTION
This is an update to the github actions CI file from DPF.
List of changes:
- cleanup whitespace
- fix armhf/aarch64 builds missing UI support
- show list of build features for each build (OS and enabled makefile vars)
- add plugin validation test (lv2 syntax, metadata and binary, plus runtime memory error check)

Note that plugin validation step fails because of uninitialised variables.
```
==7600== Conditional jump or move depends on uninitialised value(s)
==7600==    at 0x4BA7531: __expf_fma (e_expf.c:62)
==7600==    by 0xA84B85E: pow (cmath:389)
==7600==    by 0xA84B85E: fv3::strev_f::setrt60(float) (strev.cpp:131)
==7600==    by 0xA84C004: fv3::strev_f::strev_f() (strev.cpp:35)
==7600==    by 0xA8463A9: DragonflyReverbDSP::DragonflyReverbDSP(double) (DSP.cpp:130)
==7600==    by 0xA84CFDA: DISTRHO::DragonflyReverbPlugin::DragonflyReverbPlugin() (Plugin.cpp:23)
```
This is actually a good thing, we can now see when new commits introduce memory or other errors.

I confirmed with DPF example plugins and a few others that these tests do indeed work, and DPF by itself will not cause them.
It can be a bit annoying that automated build breaks, but IMO it is for the best since these kind of errors are quite important to fix - uninitialised means undefined behaviour, like loud burts when loading the plugin.
