### PR TITLE
Fix missing enum properties for a few parameters, adjust range

### DIFF
--- a/plugins/dragonfly-early-reflections/DistrhoPluginInfo.h
+++ b/plugins/dragonfly-early-reflections/DistrhoPluginInfo.h
@@ -47,7 +47,7 @@ enum Parameters
 static const Param PARAMS[paramCount] = {
   {paramDry,        "Dry Level",    "dry_level",      0.0f,   100.0f,   "%"},
   {paramWet,        "Wet Level",    "early_level",    0.0f,   100.0f,   "%"},
-  {paramProgram,    "Program",      "program",        0.0f,     6.0f,    ""},
+  {paramProgram,    "Program",      "program",        0.0f,     7.0f,    ""},
   {paramSize,       "Size",         "size",          10.0f,    60.0f,   "m"},
   {paramWidth,      "Width",        "width",         50.0f,   150.0f,   "%"},
   {paramLowCut,     "Low Cut",      "low_cut",        0.0f,   200.0f,  "Hz"},

--- a/plugins/dragonfly-early-reflections/Plugin.cpp
+++ b/plugins/dragonfly-early-reflections/Plugin.cpp
@@ -34,6 +34,17 @@ void DragonflyReverbPlugin::initParameter(uint32_t index, Parameter& parameter) 
     parameter.ranges.def = DEFAULTS[index];
     parameter.ranges.max = PARAMS[index].range_max;
     parameter.unit       = PARAMS[index].unit;
+    if (index == paramProgram) {
+      parameter.hints   |= kParameterIsInteger;
+      parameter.enumValues.count = PROGRAM_COUNT;
+      parameter.enumValues.restrictedMode = true;
+      ParameterEnumerationValue* const values = new ParameterEnumerationValue[PROGRAM_COUNT];
+      parameter.enumValues.values = values;
+      for (int i=0; i<PROGRAM_COUNT; ++i) {
+        values[i].label = programs[i].name;
+        values[i].value = i;
+      }
+    }
   }
 }
 

--- a/plugins/dragonfly-plate-reverb/Plugin.cpp
+++ b/plugins/dragonfly-plate-reverb/Plugin.cpp
@@ -36,6 +36,17 @@ void DragonflyReverbPlugin::initParameter(uint32_t index, Parameter& parameter) 
     parameter.ranges.def = presets[DEFAULT_PRESET].params[index];
     parameter.ranges.max = PARAMS[index].range_max;
     parameter.unit       = PARAMS[index].unit;
+    if (index == paramAlgorithm) {
+      parameter.hints   |= kParameterIsInteger;
+      parameter.enumValues.count = ALGORITHM_COUNT;
+      parameter.enumValues.restrictedMode = true;
+      ParameterEnumerationValue* const values = new ParameterEnumerationValue[ALGORITHM_COUNT];
+      parameter.enumValues.values = values;
+      for (int i=0; i<ALGORITHM_COUNT; ++i) {
+        values[i].label = algorithmNames[i];
+        values[i].value = i;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
As title says.
These were missing from the exported ttl and host-exposed information, so now the generic UI becomes a bit more useful.