### PR TITLE
Update links to version 3.2.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ Dragonfly Reverb is a bundle of free audio effects for Linux, MacOS, and Windows
 
 ## Download
 
-* **[Linux](https://github.com/michaelwillis/dragonfly-reverb/releases/download/3.2.5/DragonflyReverb-Linux-64bit-v3.2.5.tgz)**
-* **[MacOS](https://github.com/michaelwillis/dragonfly-reverb/releases/download/3.2.5/DragonflyReverb-MacOS-64bit-v3.2.5.zip)**
-* **[Windows (32 bit)](https://github.com/michaelwillis/dragonfly-reverb/releases/download/3.2.5/DragonflyReverb-Windows-32bit-v3.2.5.zip)**
-* **[Windows (64 bit)](https://github.com/michaelwillis/dragonfly-reverb/releases/download/3.2.5/DragonflyReverb-Windows-64bit-v3.2.5.zip)**
+* **[Linux](https://github.com/michaelwillis/dragonfly-reverb/releases/download/3.2.7/dragonfly-reverb-linux-x86_64-3.2.7.zip)**
+* **[MacOS](https://github.com/michaelwillis/dragonfly-reverb/releases/download/3.2.7/dragonfly-reverb-mac-universal-3.2.7.zip)**
+* **[Windows (32 bit)](https://github.com/michaelwillis/dragonfly-reverb/releases/download/3.2.7/dragonfly-reverb-win32-3.2.7.zip)**
+* **[Windows (64 bit)](https://github.com/michaelwillis/dragonfly-reverb/releases/download/3.2.7/dragonfly-reverb-win64-3.2.7.zip)**
 
 ## Dependencies
 

--- a/docs/donations.html
+++ b/docs/donations.html
@@ -7,7 +7,7 @@
     <div class="header">
       <a href="index.html"><img src="images/title.png" alt="Dragonfly Reverb" /></a>
       <div class="navigation">
-	<a href="https://github.com/michaelwillis/dragonfly-reverb/releases/tag/3.2.5">
+	<a href="https://github.com/michaelwillis/dragonfly-reverb/releases/tag/3.2.7">
 	  <svg viewBox="-6 -2 16 16" height="32" width="36" aria-hidden="true"><path fill-rule="evenodd" d="M7 7V3H3v4H0l5 6 5-6H7z"></path></svg>
 	  Download
 	</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -7,7 +7,7 @@
     <div class="header">
       <a href="index.html"><img src="images/title.png" alt="Dragonfly Reverb" /></a>
       <div class="navigation">
-	<a href="https://github.com/michaelwillis/dragonfly-reverb/releases/tag/3.2.5">
+	<a href="https://github.com/michaelwillis/dragonfly-reverb/releases/tag/3.2.7">
 	  <svg viewBox="-6 -2 16 16" height="32" width="36" aria-hidden="true"><path fill-rule="evenodd" d="M7 7V3H3v4H0l5 6 5-6H7z"></path></svg>
 	  Download
 	</a>

--- a/docs/manuals.html
+++ b/docs/manuals.html
@@ -7,7 +7,7 @@
     <div class="header">
       <a href="index.html"><img src="images/title.png" alt="Dragonfly Reverb" /></a>
       <div class="navigation">
-	<a href="https://github.com/michaelwillis/dragonfly-reverb/releases/tag/3.2.5">
+	<a href="https://github.com/michaelwillis/dragonfly-reverb/releases/tag/3.2.7">
 	  <svg viewBox="-6 -2 16 16" height="32" width="36" aria-hidden="true"><path fill-rule="evenodd" d="M7 7V3H3v4H0l5 6 5-6H7z"></path></svg>
 	  Download
 	</a>


### PR DESCRIPTION
The README and the website both still point to version 3.2.5. I think this can be updated, right?